### PR TITLE
fix typo

### DIFF
--- a/A:/src/Crylix-main/kernel/kernel.asm
+++ b/A:/src/Crylix-main/kernel/kernel.asm
@@ -77,7 +77,7 @@ call panic; panic! the memory doesn't work!
 shell_init:
   xor A, A
   load A, shell_init_string
-  call print char
+  call print_char
   xor A,A
   %include A:/bin/shell.asm
   call init


### PR DESCRIPTION
I think you meant `print_char`